### PR TITLE
Improve class naming + db error catching

### DIFF
--- a/administrator/components/com_admin/models/profile.php
+++ b/administrator/components/com_admin/models/profile.php
@@ -60,7 +60,7 @@ class AdminModelProfile extends UsersModelUser
 		// When multilanguage is set, a user's default site language should also be a Content Language
 		if (JLanguageMultilang::isEnabled())
 		{
-			$form->setFieldAttribute('language', 'type', 'frontendlanguage', 'params');
+			$form->setFieldAttribute('language', 'type', 'frontend_language', 'params');
 		}
 
 		// If the user needs to change their password, mark the password fields as required

--- a/administrator/components/com_users/models/user.php
+++ b/administrator/components/com_users/models/user.php
@@ -137,7 +137,7 @@ class UsersModelUser extends JModelAdmin
 		// When multilanguage is set, a user's default site language should also be a Content Language
 		if (JLanguageMultilang::isEnabled())
 		{
-			$form->setFieldAttribute('language', 'type', 'frontendlanguage', 'params');
+			$form->setFieldAttribute('language', 'type', 'frontend_language', 'params');
 		}
 
 		// The user should not be able to set the requireReset value on their own account

--- a/components/com_users/models/profile.php
+++ b/components/com_users/models/profile.php
@@ -218,7 +218,7 @@ class UsersModelProfile extends JModelForm
 		// When multilanguage is set, a user's default site language should also be a Content Language
 		if (JLanguageMultilang::isEnabled())
 		{
-			$form->setFieldAttribute('language', 'type', 'frontendlanguage', 'params');
+			$form->setFieldAttribute('language', 'type', 'frontend_language', 'params');
 		}
 
 		// If the user needs to change their password, mark the password fields as required

--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -270,7 +270,7 @@ class UsersModelRegistration extends JModelForm
 		// When multilanguage is set, a user's default site language should also be a Content Language
 		if (JLanguageMultilang::isEnabled())
 		{
-			$form->setFieldAttribute('language', 'type', 'frontendlanguage', 'params');
+			$form->setFieldAttribute('language', 'type', 'frontend_language', 'params');
 		}
 
 		if (empty($form))

--- a/libraries/cms/form/field/frontend_language.php
+++ b/libraries/cms/form/field/frontend_language.php
@@ -18,7 +18,7 @@ JFormHelper::loadFieldClass('list');
  * @see    JFormFieldLanguage for a select list of application languages.
  * @since  1.6
  */
-class JFormFieldFrontendlanguage extends JFormFieldList
+class JFormFieldFrontend_Language extends JFormFieldList
 {
 	/**
 	 * The form field type.
@@ -26,7 +26,7 @@ class JFormFieldFrontendlanguage extends JFormFieldList
 	 * @var    string
 	 * @since  1.6
 	 */
-	public $type = 'FrontendLanguage';
+	public $type = 'Frontend_Language';
 
 	/**
 	 * Method to get the field options for frontend published content languages with homes.
@@ -41,7 +41,7 @@ class JFormFieldFrontendlanguage extends JFormFieldList
 		$db    = JFactory::getDbo();
 		$query = $db->getQuery(true);
 
-		$query->select('a.lang_code AS value, a.title AS text, a.title_native', 'l.home')
+		$query->select('a.lang_code AS value, a.title AS text')
 				->from($db->quoteName('#__languages') . ' AS a')
 				->where('a.published = 1')
 				->order('a.title');
@@ -56,7 +56,19 @@ class JFormFieldFrontendlanguage extends JFormFieldList
 
 		$db->setQuery($query);
 
-		$languages = $db->loadObjectList();
+		try
+		{
+			$languages = $db->loadObjectList();
+		}
+		catch (RuntimeException $e)
+		{
+			$languages = array();
+
+			if (JFactory::getUser()->authorise('core.admin'))
+			{
+				JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+			}
+		}
 
 		// Merge any additional options in the XML definition.
 		$options = array_merge(


### PR DESCRIPTION
Let's avoid ugly class names when possible. Also the db query is catched to avoid throwing errors if the user is not an admin
