### PR TITLE
Directly change the module title in the module.

### DIFF
--- a/administrator/modules/mod_latest/mod_latest.php
+++ b/administrator/modules/mod_latest/mod_latest.php
@@ -13,4 +13,10 @@ defined('_JEXEC') or die;
 require_once __DIR__ . '/helper.php';
 
 $list = ModLatestHelper::getList($params);
+
+if ($params->get('automatic_title', 0))
+{
+	$module->title = ModLatestHelper::getTitle($params);
+}
+
 require JModuleHelper::getLayoutPath('mod_latest', $params->get('layout', 'default'));

--- a/administrator/modules/mod_latest/mod_latest.xml
+++ b/administrator/modules/mod_latest/mod_latest.xml
@@ -96,9 +96,9 @@
 					label="COM_MODULES_FIELD_AUTOMATIC_TITLE_LABEL"
 					description="COM_MODULES_FIELD_AUTOMATIC_TITLE_DESC">
 					<option
-						value="0">JNO</option>
-					<option
 						value="1">JYES</option>
+					<option
+						value="0">JNO</option>
 				</field>
 			</fieldset>
 		</fields>

--- a/administrator/modules/mod_logged/mod_logged.php
+++ b/administrator/modules/mod_logged/mod_logged.php
@@ -14,4 +14,9 @@ require_once __DIR__ . '/helper.php';
 
 $users = ModLoggedHelper::getList($params);
 
+if ($params->get('automatic_title', 0))
+{
+	$module->title = ModLoggedHelper::getTitle($params);
+}
+
 require JModuleHelper::getLayoutPath('mod_logged', $params->get('layout', 'default'));

--- a/administrator/modules/mod_logged/mod_logged.xml
+++ b/administrator/modules/mod_logged/mod_logged.xml
@@ -70,9 +70,9 @@
 					label="COM_MODULES_FIELD_AUTOMATIC_TITLE_LABEL"
 					description="COM_MODULES_FIELD_AUTOMATIC_TITLE_DESC">
 					<option
-						value="0">JNO</option>
-					<option
 						value="1">JYES</option>
+					<option
+						value="0">JNO</option>
 				</field>
 			</fieldset>
 		</fields>

--- a/administrator/modules/mod_popular/mod_popular.php
+++ b/administrator/modules/mod_popular/mod_popular.php
@@ -15,5 +15,10 @@ require_once __DIR__ . '/helper.php';
 // Get module data.
 $list = ModPopularHelper::getList($params);
 
+if ($params->get('automatic_title', 0))
+{
+	$module->title = ModPopularHelper::getTitle($params);
+}
+
 // Render the module
 require JModuleHelper::getLayoutPath('mod_popular', $params->get('layout', 'default'));

--- a/administrator/modules/mod_popular/mod_popular.xml
+++ b/administrator/modules/mod_popular/mod_popular.xml
@@ -85,9 +85,9 @@
 					label="COM_MODULES_FIELD_AUTOMATIC_TITLE_LABEL"
 					description="COM_MODULES_FIELD_AUTOMATIC_TITLE_DESC">
 					<option
-						value="0">JNO</option>
-					<option
 						value="1">JYES</option>
+					<option
+						value="0">JNO</option>
 				</field>
 			</fieldset>
 		</fields>

--- a/libraries/cms/module/helper.php
+++ b/libraries/cms/module/helper.php
@@ -192,20 +192,6 @@ abstract class JModuleHelper
 			ob_end_clean();
 		}
 
-		// Automatic title
-		if ($params->get('automatic_title', '0') == '0')
-		{
-			$module->title = $module->title;
-		}
-		elseif (method_exists('mod' . $module->name . 'Helper', 'getTitle'))
-		{
-			$module->title = call_user_func_array(array('mod' . $module->name . 'Helper', 'getTitle'), array($params));
-		}
-		else
-		{
-			$module->title = JText::_('MOD_' . $module->name . '_TITLE');
-		}
-
 		// Load the module chrome functions
 		if (!$chrome)
 		{


### PR DESCRIPTION
After looking how modules actually are processed I saw that the $module->title property is set before the content is retrieved from the module. Which means we can manipulate it directly in the module. Which amkes the code self contained in the module and there is no need to change anything in the libraries.

I also changed No/Yes to Yes/No so it's consistent with other Yes/No choices :smile: 
