### PR TITLE
[4.0] Check for both old (pseudo-)null dates and real NULL values in Jgrid and Published buttons

### DIFF
--- a/libraries/cms/html/jgrid.php
+++ b/libraries/cms/html/jgrid.php
@@ -194,13 +194,13 @@ abstract class JHtmlJGrid
 		// Special state for dates
 		if ($publish_up || $publish_down)
 		{
-			$nullDate = null;
+			$nullDate = Factory::getDbo()->getNullDate();
 			$nowDate = Factory::getDate()->toUnix();
 
 			$tz = Factory::getUser()->getTimezone();
 
-			$publish_up = ($publish_up != $nullDate) ? Factory::getDate($publish_up, 'UTC')->setTimeZone($tz) : false;
-			$publish_down = ($publish_down != $nullDate) ? Factory::getDate($publish_down, 'UTC')->setTimeZone($tz) : false;
+			$publish_up = ($publish_up !== null && $publish_up !== $nullDate) ? Factory::getDate($publish_up, 'UTC')->setTimeZone($tz) : false;
+			$publish_down = ($publish_down !== null && $publish_down !== $nullDate) ? Factory::getDate($publish_down, 'UTC')->setTimeZone($tz) : false;
 
 			// Create tip text, only we have publish up or down settings
 			$tips = array();

--- a/libraries/src/Button/PublishedButton.php
+++ b/libraries/src/Button/PublishedButton.php
@@ -55,13 +55,13 @@ class PublishedButton extends ActionButton
 			$bakState = $this->getState($value);
 			$default  = $this->getState($value) ? : $this->getState('_default');
 
-			$nullDate = null;
+			$nullDate = Factory::getDbo()->getNullDate();
 			$nowDate = Factory::getDate()->toUnix();
 
 			$tz = Factory::getUser()->getTimezone();
 
-			$publishUp   = ($publishUp !== $nullDate) ? Factory::getDate($publishUp, 'UTC')->setTimeZone($tz) : null;
-			$publishDown = ($publishDown !== $nullDate) ? Factory::getDate($publishDown, 'UTC')->setTimeZone($tz) : null;
+			$publishUp   = ($publishUp !== null && $publishUp !== $nullDate) ? Factory::getDate($publishUp, 'UTC')->setTimeZone($tz) : false;
+			$publishDown = ($publishDown !== null && $publishDown !== $nullDate) ? Factory::getDate($publishDown, 'UTC')->setTimeZone($tz) : false;
 
 			// Add tips and special titles
 			// Create special titles for published items
@@ -86,13 +86,13 @@ class PublishedButton extends ActionButton
 
 				$options['tip_title'] = 'JLIB_HTML_PUBLISHED_ITEM';
 
-				if ($publishUp > $nullDate && $nowDate < $publishUp->toUnix())
+				if ($publishUp && $nowDate < $publishUp->toUnix())
 				{
 					$options['tip_title'] = 'JLIB_HTML_PUBLISHED_PENDING_ITEM';
 					$default['icon'] = 'pending';
 				}
 
-				if ($publishDown > $nullDate && $nowDate > $publishDown->toUnix())
+				if ($publishDown && $nowDate > $publishDown->toUnix())
 				{
 					$options['tip_title'] = 'JLIB_HTML_PUBLISHED_EXPIRED_ITEM';
 					$default['icon'] = 'expired';


### PR DESCRIPTION
PR for [https://github.com/joomla/joomla-cms/pull/26751](https://github.com/joomla/joomla-cms/pull/26751).

This should do it, but I'm at work and so can't test before tonight German time.